### PR TITLE
Make sitemap URLs absolute

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -119,6 +119,20 @@ module.exports = function (config) {
     ghostMode: false,
   });
 
+  // Set baseurl based on site.yaml definitions and Cloud.gov's BRANCH environment variable
+  let baseUrl = domains.local;
+  if (process.env.BRANCH) {
+    switch (process.env.BRANCH) {
+      case 'main':
+        baseUrl = domains.prod;
+        break;
+      default:
+        baseUrl = `${domains.staging}/${process.env.BRANCH}`;
+        break; 
+    }
+  }
+  config.addGlobalData("baseUrl", baseUrl);
+
   // Set image shortcodes
   config.addLiquidShortcode('image', imageShortcode);
   config.addLiquidShortcode('image_with_class', imageWithClassShortcode);

--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -98,6 +98,13 @@ searchgov:
   # If you do not want to present search suggestions, set this value to false.
   suggestions: true
 
+  # Used for generating baseurls (important for sitemap.xml to work properly)
+  # Replace prod and staging values with your production URL and your Pages preview URL
+  domains:
+    prod: replaceMe.gov
+    staging:  federalist-replaceMe.sites.pages.cloud.gov/preview/yourOrgName/yourRepoName
+    local: http://localhost:8080
+
 ##########################################################################################
 # The values below here are more advanced and should only be
 # changed if you know what they do

--- a/sitemap.xml.njk
+++ b/sitemap.xml.njk
@@ -5,7 +5,7 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {%- for page in collections.all %}
-  {% set absoluteUrl %}{{ page.url | url | absoluteUrl }}{% endset %}
+  {% set absoluteUrl %}{{ baseUrl }}{{ page.url }}{% endset %}
   <url>
     <loc>{{ absoluteUrl }}</loc>
     <lastmod>{{ page.date | htmlDateString }}</lastmod>


### PR DESCRIPTION
Proposed fix for #63. [I wrote this for the client site I'm working on](https://github.com/CRCCRRB/cold-case-review-board-website/pull/48) -- use it if it's useful, don't if it's not!

## Changes proposed in this pull request:
- Adds YAML values to `site.yaml` for various domains
- Adds a function to `.eleventy` to generate a variable containing the absolute URL path
- Uses the above-mentioned variable in `sitemap.xml`

## security considerations
None that I'm aware of