### PR TITLE
Performance changes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -15,9 +15,6 @@ module.exports = function (config) {
   // Copy the `admin` folders to the output
   config.addPassthroughCopy('admin');
 
-  // Copy USWDS init JS so we can load it in HEAD to prevent banner flashing
-  config.addPassthroughCopy({'./node_modules/@uswds/uswds/dist/js/uswds-init.js': 'assets/js/uswds-init.js'});
-
   // Add plugins
   config.addPlugin(pluginRss);
   config.addPlugin(pluginNavigation);

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ web_modules/
 _site
 public
 node_modules
+_data/assetPaths.json

--- a/_data/assetPaths.json
+++ b/_data/assetPaths.json
@@ -1,9 +1,0 @@
-{
-  "admin.js": "/assets/js/admin-OYJBR6FH.js",
-  "admin.map": "/assets/js/admin-OYJBR6FH.js.map",
-  "app.js": "/assets/js/app-ZQYILJ3O.js",
-  "app.map": "/assets/js/app-ZQYILJ3O.js.map",
-  "uswds.js": "/assets/js/uswds-init.js",
-  "styles.css": "/assets/styles/styles-BBYPEDQ2.css",
-  "styles.map": "/assets/styles/styles-BBYPEDQ2.css.map"
-}

--- a/_includes/layouts/base.html
+++ b/_includes/layouts/base.html
@@ -1,9 +1,8 @@
+<!DOCTYPE html>
 {% comment %}
 This is used for just about every page. It provides the border around the content.
 The home page uses wide.html layout, since it extends full width of page
 {% endcomment %}
-
-<!DOCTYPE html>
 
 <html lang="en">
 

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -30,7 +30,7 @@ to modify some of the meta-data for the site, this is the place to do it.
   <link rel="canonical" href="{{ page.url }}" />
   <meta property="og:url" content="{{ page.url }}" />
 
-  <script src="{{ assetPaths['uswds.js'] }} "></script>
+  <script src="{{ assetPaths['uswds-init.js'] }}"></script>
   <!-- CSS
     ================================================== -->
   <link rel="stylesheet" href="{{ assetPaths['styles.css'] }}" type="text/css" />
@@ -43,6 +43,6 @@ to modify some of the meta-data for the site, this is the place to do it.
   {% endcomment %}
   <link rel="preload" href="{{ assetPaths['PublicSans-Regular.woff2'] }}" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="{{ assetPaths['PublicSans-Bold.woff2'] }}" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="{{ assetPaths['Latin-Merriweather-Bold-.woff2'] }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ assetPaths['Latin-Merriweather-Bold.woff2'] }}" as="font" type="font/woff2" crossorigin>
 
 </head>

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -29,9 +29,8 @@ to modify some of the meta-data for the site, this is the place to do it.
   <meta property="og:type" content="article" />
   <link rel="canonical" href="{{ page.url }}" />
   <meta property="og:url" content="{{ page.url }}" />
-  <script async="" src="{{ assetPaths['uswds.js'] }} "></script>
+  <script src="{{ assetPaths['uswds.js'] }} "></script>
   <!-- CSS
     ================================================== -->
-    <link rel="preload" as="style" href="{{ assetPaths['styles.css'] }}" />
     <link rel="stylesheet" href="{{ assetPaths['styles.css'] }}" type="text/css" />
 </head>

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -29,8 +29,20 @@ to modify some of the meta-data for the site, this is the place to do it.
   <meta property="og:type" content="article" />
   <link rel="canonical" href="{{ page.url }}" />
   <meta property="og:url" content="{{ page.url }}" />
+
   <script src="{{ assetPaths['uswds.js'] }} "></script>
   <!-- CSS
     ================================================== -->
-    <link rel="stylesheet" href="{{ assetPaths['styles.css'] }}" type="text/css" />
+  <link rel="stylesheet" href="{{ assetPaths['styles.css'] }}" type="text/css" />
+
+  {% comment %}
+  Preload only the files that are needed for the content in the initial viewport. This
+  will likely include the fonts needed for the navigation, page heading, and the font needed for the
+  first paragraph of body copy. The `crossorigin` attribute may be required based on the type
+  of asset you wish to preload in order for the preload to work properly.
+  {% endcomment %}
+  <link rel="preload" href="{{ assetPaths['PublicSans-Regular.woff2'] }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ assetPaths['PublicSans-Bold.woff2'] }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ assetPaths['Latin-Merriweather-Bold-.woff2'] }}" as="font" type="font/woff2" crossorigin>
+
 </head>

--- a/config/buildAssets.js
+++ b/config/buildAssets.js
@@ -4,18 +4,22 @@ const esbuild = require('esbuild');
 const { sassPlugin } = require('esbuild-sass-plugin');
 
 async function createAssetPaths() {
-  let pathPrefix = ''
+  let pathPrefix = '';
 
   if (process.env.BASEURL) {
-    pathPrefix = process.env.BASEURL
+    pathPrefix = process.env.BASEURL;
   }
 
   const assetPath = path.join(__dirname, '../_site/assets');
-  const assetDirs = await fs.readdir(assetPath);
+  let assetDirs = await fs.readdir(assetPath, { withFileTypes: true });
+  assetDirs = assetDirs
+    .filter((item) => item.isDirectory())
+    .map((item) => item.name);
+
   const assetsFiles = await Promise.all(
     assetDirs.map(async (dir) => {
       const files = await fs.readdir(
-        path.join(__dirname, '../_site/assets', dir)
+        path.join(__dirname, '../_site/assets', dir),
       );
       return files.map((file) => {
         const { name, ext } = path.parse(file);
@@ -41,11 +45,14 @@ esbuild
     outdir: '_site/assets',
     format: 'iife',
     loader: {
-      '.png': 'dataurl',
-      '.svg': 'dataurl',
-      '.ttf': 'dataurl',
-      '.woff': 'dataurl',
-      '.woff2': 'dataurl',
+      '.jpg': 'file',
+      '.gif': 'file',
+      '.png': 'file',
+      '.webp': 'file',
+      '.svg': 'file',
+      '.ttf': 'file',
+      '.woff': 'file',
+      '.woff2': 'file',
     },
     minify: process.env.ELEVENTY_ENV === 'production',
     sourcemap: process.env.ELEVENTY_ENV !== 'production',

--- a/config/buildAssets.js
+++ b/config/buildAssets.js
@@ -61,7 +61,7 @@ async function createAssetPaths() {
 
 esbuild
   .build({
-    entryPoints: ['styles/styles.scss', 'js/app.js', 'js/admin.js'],
+    entryPoints: ['styles/styles.scss', 'js/app.js', 'js/admin.js', 'js/uswds-init.js'],
     entryNames: '[dir]/[name]-[hash]',
     outdir: '_site/assets',
     format: 'iife',

--- a/js/uswds-init.js
+++ b/js/uswds-init.js
@@ -1,0 +1,2 @@
+// require('../node_modules/@uswds/uswds/uswds-init.js');
+require('../node_modules/@uswds/uswds/dist/js/uswds-init');

--- a/js/uswds-init.js
+++ b/js/uswds-init.js
@@ -1,2 +1,1 @@
-// require('../node_modules/@uswds/uswds/uswds-init.js');
 require('../node_modules/@uswds/uswds/dist/js/uswds-init');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev:debug": "DEBUG=* npx @11ty/eleventy --serve --watch",
     "dev:serve": "npx @11ty/eleventy --serve --watch",
     "dev:cms": "npx decap-server",
-    "federalist": "npm run build",
+    "federalist": "ELEVENTY_ENV=production npm run build",
     "serve": "npx @11ty/eleventy --serve",
     "start": "npx @11ty/eleventy --serve",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "assets:refresh": "npm run assets:clean && npm run assets:build",
     "assets:watch": "chokidar 'js/**' 'styles/**' -c 'npm run assets:refresh' --polling",
     "clean": "rimraf _site",
-    "dev": "npm run clean && npm-run-all -p dev:assets dev:serve",
+    "dev": "npm run clean && npm run assets:build && npm-run-all -p dev:assets dev:serve",
     "dev:clean": "npm run clean && npm run dev",
     "dev:assets": "npm run assets:refresh && npm run assets:watch",
     "dev:debug": "DEBUG=* npx @11ty/eleventy --serve --watch",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "npm run assets:build && npx @11ty/eleventy",
-    "assets:autoprefix": "postcss _site/assets/styles/*.css -r --use autoprefixer",
+    "assets:autoprefix": "postcss _site/assets/styles/*.css -r",
     "assets:build": "node ./config/buildAssets && npm run assets:autoprefix",
     "assets:clean": "rimraf _site/assets",
     "assets:refresh": "npm run assets:clean && npm run assets:build",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,7 @@
 module.exports = {
-  plugins: [require('autoprefixer')],
+    plugins: [
+        require('autoprefixer')({
+            map: process.env.ELEVENTY_ENV !== 'production'
+        }),
+    ],
 };


### PR DESCRIPTION
This pertained originally to https://github.com/cloud-gov/pages-uswds-11ty/pull/61 that inadvertently got closed (by me). 

## Changes proposed in this pull request:
- set env var in `federalist` npm task so the assets get minified in the production build and source maps get removed
- Remove the `--use` flag from postcss so the settings in `postcss.config.js` are not overridden.
- `config/buildAssets.js` file was modified to use external files instead of data uris
- `createAssetPath` was updated to account for the output change necessary to use the external file.
- `_data/assetPaths.json` was removed from git because it's a build asset and is generated every time by the build process.
- Add new build file for `uswds-init.js` so it is hashed for future cache TTL updates.

### Requested changes on the original PR
- preloaded homepage fonts (now that they are removed from the css). This required a new function in the `config/buildAssets.js` file (completed)
- remove cross-env dependency (completed)
- update build target (not completed). My understanding of what this did was incorrect. This is used for JS and not for autoprefixer. esbuild does not support browserslist - See: https://github.com/evanw/esbuild/issues/121


## security considerations
None. This is presentational only and no new dependencies were added.
